### PR TITLE
Player IP Security and 3rd eye Target add

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,5 +1,11 @@
--- Events
+Config = {}
+Config.PrinterModels = {
+    {model = 'prop_printer_02'},
+    {model = 'prop_printer_01'},
+    {model = 'v_res_printer'},
+}
 
+-- Events
 RegisterNetEvent('qb-printer:client:UseDocument', function(ItemData)
     local DocumentUrl = ItemData.info.url ~= nil and ItemData.info.url or false
     SendNUIMessage({
@@ -26,6 +32,35 @@ RegisterNetEvent('qb-printer:client:SpawnPrinter', function()
     SetEntityAsMissionEntity(obj)
 end)
 
+RegisterNetEvent("qb-printer:use")
+AddEventHandler('qb-printer:use', function()
+    SendNUIMessage({
+        action = "start"
+    })
+    SetNuiFocus(true, true)
+end)
+
+-- Threads
+CreateThread(function()
+    while true do
+        local ped = PlayerPedId()
+        local pos = GetEntityCoords(ped)
+        for k, v in pairs(Config.PrinterModels) do
+            local PrinterObject = GetClosestObjectOfType(pos.x, pos.y, pos.z, 1.5, GetHashKey(v.model), false, false, false)
+            if PrinterObject ~= 0 then
+                local PrinterCoords = GetEntityCoords(PrinterObject)
+                exports['qb-target']:AddBoxZone("Printer", PrinterCoords, 0.4, 0.4, { name="Printer", heading = 0, debugPoly=false, minZ=PrinterCoords.z, maxZ=PrinterCoords.z+0.4 }, 
+                    { options = { { event = "qb-printer:use", icon = "fas fa-cash-register", label = "Printer" }, },
+                    distance = 3.0
+                })
+            else
+                Wait(1000)
+            end
+        end
+        Wait(3)
+    end
+end)
+
 -- NUI
 
 RegisterNUICallback('SaveDocument', function(data, cb)
@@ -41,7 +76,6 @@ RegisterNUICallback('CloseDocument', function(_, cb)
 end)
 
 -- Command
-
 RegisterCommand('useprinter', function()
     local ped = PlayerPedId()
     local pos = GetEntityCoords(ped)

--- a/server/main.lua
+++ b/server/main.lua
@@ -34,7 +34,7 @@ RegisterNetEvent('qb-printer:server:SaveDocument', function(url)
         end
     end
     if url ~= nil then
-        if urlStart ~= nil then
+        if urlEnd ~= nil then
             local host = string.sub(url, urlStart, urlEnd)
             local validexts = ValidExtensions
             local validHosts = ValidHosts

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,12 +1,17 @@
 local QBCore = exports['qb-core']:GetCoreObject()
-
 local ValidExtensions = {
     [".png"] = true,
     [".gif"] = true,
     [".jpg"] = true,
     ["jpeg"] = true
 }
-
+local ValidHosts = { -- ["host"] = spacing count,
+    ["discord.com"] = 10,
+    ["discordapp.com"] = 13,
+    ["imgur.com"] = 8,
+    ["gyazo.com"] = 8,
+    ["google.com"] = 9,
+}
 local ValidExtensionsText = '.png, .gif, .jpg, .jpeg'
 
 QBCore.Functions.CreateUseableItem("printerdocument", function(source, item)
@@ -22,14 +27,31 @@ RegisterNetEvent('qb-printer:server:SaveDocument', function(url)
     local Player = QBCore.Functions.GetPlayer(src)
     local info = {}
     local extension = string.sub(url, -4)
-    local validexts = ValidExtensions
-    if url ~= nil then
-        if validexts[extension] then
-            info.url = url
-            Player.Functions.AddItem('printerdocument', 1, nil, info)
-            TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items['printerdocument'], "add")
-        else
-            TriggerClientEvent('QBCore:Notify', src, 'Thats not a valid extension, only '..ValidExtensionsText..' extension links are allowed.', "error")
+    for k,v in pairs(ValidHosts) do
+        urlStart = string.find(url, k)
+        if urlStart ~= nil then
+            urlEnd = urlStart + v
         end
+    end
+    if url ~= nil then
+        if urlStart ~= nil then
+            local host = string.sub(url, urlStart, urlEnd)
+            local validexts = ValidExtensions
+            local validHosts = ValidHosts
+            if validHosts[host] then
+                if validexts[extension] then
+                    info.url = url
+                    Player.Functions.AddItem('printerdocument', 1, nil, info)
+                    TriggerClientEvent('inventory:client:ItemBox', src, QBCore.Shared.Items['printerdocument'], "add")
+                    urlStart = nil
+                else
+                    TriggerClientEvent('QBCore:Notify', src, 'Thats not a valid extension, only '..ValidExtensionsText..' extension links are allowed.', "error")
+                end
+            end
+        else
+            TriggerClientEvent('QBCore:Notify', src, 'This is not a trusted image host', "error")
+        end
+    else
+        TriggerClientEvent('QBCore:Notify', src, 'This is not a valid URL', "error")
     end
 end)


### PR DESCRIPTION
EXPLOIT:  If a player uses their own webhosting as a link when printing, the players IPs that open that document are revieled to that player if they simply watch the connections to their hosting.


This contains:
Client:
 - Added the ability to 3rd eye the main models of printers so ones do not need to be spawned and players can use them.

Server:
 - Added a valid hosting check, it's also setup to capture the host for my own logging purposes but you can remove that. The main goal was to stop the exploit. 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes, this has been running on our live envioronment for a few days.
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes
